### PR TITLE
Fix typo and update repo link in privacy policy

### DIFF
--- a/privacy.md
+++ b/privacy.md
@@ -3,7 +3,7 @@
 CubeTime itself does not collect any data, "personal" or otherwise.    
 Your solves (data not comprising of personal information including but not limited to the "scramble" used, the date of the solve, the time taken to complete the solve) and your sessions (data including but not limited to named groups of solves, again with no personal data) are stored locally on your device only, unless you are signed into an iCloud account *and* choose to sync your sessions and solves between iCloud-enabled devices.
 
-**Optionally**, CubeTime will use Apple iCloud to store your sessions. CubeTime's data that is stored on iCloud can be viewed and deleted in the CubeTime app. This data is handled by Apple's CloudKit service, which is encypted by an account-based key. Your data is stored in a privacy database and we do **not** have acccess to this data. Additionally, we do **not** have access to your Apple ID.
+**Optionally**, CubeTime will use Apple iCloud to store your sessions. CubeTime's data that is stored on iCloud can be viewed and deleted in the CubeTime app. This data is handled by Apple's CloudKit service, which is encypted by an account-based key. Your data is stored in a privacy database and we do **not** have access to this data. Additionally, we do **not** have access to your Apple ID.
 The Apple iCloud privacy policy is available at https://www.apple.com/legal/privacy/, and further Apple platform security can be viewed [here](https://support.apple.com/en-is/guide/security/welcome/web).
 
 The source code of CubeTime is publically viewable at https://github.com/CubeStuffs/CubeTime for independent verification.

--- a/privacy.md
+++ b/privacy.md
@@ -6,4 +6,4 @@ Your solves (data not comprising of personal information including but not limit
 **Optionally**, CubeTime will use Apple iCloud to store your sessions. CubeTime's data that is stored on iCloud can be viewed and deleted in the CubeTime app. This data is handled by Apple's CloudKit service, which is encypted by an account-based key. Your data is stored in a privacy database and we do **not** have access to this data. Additionally, we do **not** have access to your Apple ID.
 The Apple iCloud privacy policy is available at https://www.apple.com/legal/privacy/, and further Apple platform security can be viewed [here](https://support.apple.com/en-is/guide/security/welcome/web).
 
-The source code of CubeTime is publically viewable at https://github.com/CubeStuffs/CubeTime for independent verification.
+The source code of CubeTime is publically viewable at https://github.com/CubeLabsNZ/CubeTime for independent verification.


### PR DESCRIPTION
Incredibly minor and pedantic documentation fix(es). :)

The version at https://cubetime.app/privacy seems slightly different to even the unmodified original privacy.md before my commits, so the source tree for the website (wherever that is, I couldn't find lol) should probably be updated similarly too.